### PR TITLE
compensate for updated poll interval for manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Start monitoring a new stream by doing a `PUT` to `hls-monitor-endpoint/create` 
 
 ```json
 {
-  "streams": ["streams-to-monitor/manifest.m3u8"]
+  "streams": ["stream-to-monitor/manifest.m3u8"]
 }
 ```
 
@@ -34,8 +34,8 @@ It's also possible to set the interval (in milliseconds) for when a manifest sho
 
 ```json
 {
-  "streams": ["streams-to-monitor/manifest.m3u8"],
-  "monitorInterval": 6000
+  "streams": ["stream-to-monitor/manifest.m3u8"],
+  "staleLimit": 6000
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ It's also possible to set the interval (in milliseconds) for when a manifest sho
 ```json
 {
   "streams": ["stream-to-monitor/manifest.m3u8"],
-  "staleLimit": 6000
+  "stale-limit": 6000
 }
 ```
 

--- a/src/HLSMonitor.ts
+++ b/src/HLSMonitor.ts
@@ -12,22 +12,22 @@ export class HLSMonitor {
   private streams: string[] = [];
   private state: State;
   private streamData = new Map<string, any>();
-  private interval: number;
+  private staleLimit: number;
   private lock = new Mutex();
 
   /**
     * @param hlsStreams The streams to monitor.
-    * @param [monitorInterval] The monitor interval for streams overrides the default (6000ms) monitor interval and the HLS_MONITOR_INTERVAL environment variable.
+    * @param [staleLimit] The monitor interval for streams overrides the default (6000ms) monitor interval and the HLS_MONITOR_INTERVAL environment variable.
     */
-  constructor(hlsStreams: string[], monitorInterval?: number) {
+  constructor(hlsStreams: string[], staleLimit?: number) {
     this.streams = hlsStreams;
     this.state = State.IDLE;
-    if (monitorInterval) {
-      this.interval = monitorInterval;
+    if (staleLimit) {
+      this.staleLimit = staleLimit;
     } else {
-      this.interval = parseInt(process.env.HLS_MONITOR_INTERVAL || "6000");
+      this.staleLimit = parseInt(process.env.HLS_MONITOR_INTERVAL || "6000");
     }
-    console.log(`Monitor interval: ${this.interval}`);
+    console.log(`Stale-limit: ${this.staleLimit}`);
   }
 
   async create(streams?: string[]): Promise<void> {
@@ -38,7 +38,7 @@ export class HLSMonitor {
     while (this.state === State.ACTIVE) {
       try {
         await this.parseManifests(this.streams);
-        await timer(this.interval/2);
+        await timer(this.staleLimit/2);
       } catch (error) {
         console.error(error);
         this.state = State.INACTIVE;
@@ -146,6 +146,7 @@ export class HLSMonitor {
       return;
     }
     const manifestLoader = new HTTPManifestLoader();
+    let lastUpdated = this.staleLimit / 2;
     for (const streamUrl of streamUrls) {
       const masterM3U8 = await manifestLoader.load(streamUrl);
       let baseUrl = this.getBaseUrl(streamUrl);
@@ -206,12 +207,13 @@ export class HLSMonitor {
         data.nextIsDiscontinuity = variant.items.PlaylistItem[0].get("discontinuity");
       }
       // validate update interval (Stale manifest)
-      const updateInterval = Date.now() - data.lastFetch;
-      if (updateInterval > this.interval) {
-        error = `[${new Date().toISOString()}] Stale manifest! Expected: ${this.interval}ms Got: ${updateInterval}ms`;
+      const updateInterval = (Date.now() - data.lastFetch) - lastUpdated;
+      if (updateInterval > this.staleLimit) {
+        error = `[${new Date().toISOString()}] Stale manifest! Expected: ${this.staleLimit}ms Got: ${updateInterval}ms`;
         console.error(`[${baseUrl}]${error}`);
         data.errors.push(error);
       }
+      lastUpdated = 0;
       let currErrors = this.streamData.get(baseUrl).errors;
       currErrors.concat(data.errors);
       this.streamData.set(baseUrl, {

--- a/src/HLSMonitorService.ts
+++ b/src/HLSMonitorService.ts
@@ -153,19 +153,23 @@ export class HLSMonitorService {
             streams: resp 
           });
       } else {
-        if(body["monitorInterval"]) {
-          this.hlsMonitor = new HLSMonitor(body["streams"], body["monitorInterval"]);
+        if(body["stale_limit"]) {
+          this.hlsMonitor = new HLSMonitor(body["streams"], body["stale_limit"]);
         } else {
           this.hlsMonitor = new HLSMonitor(body["streams"]);
         }
         this.hlsMonitor.create();
+        const rep = {
+          status: "Created a new hls-monitor",
+          streams: body["streams"]
+        }
+        if(body["stale_limit"]) {
+          rep["stale_limit"] = body["stale_limit"];
+        }
         reply
           .code(201)
           .header("Content-Type", "application/json; charset=utf-8")
-          .send({ 
-            status: "Created a new hls-monitor",
-            streams: body["streams"] 
-          });
+          .send(rep);
       };
     });
   }


### PR DESCRIPTION
This PR fixes a bug introduced in #9 that would cause the monitor service to mark manifests as stale when they would actually update as they should.

The `monitorInterval` have also been renamed to `stale-limit`.