### PR TITLE
Docs: fix incorrect code example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 test.ts
+dev
 dist/
 *.swp

--- a/README.md
+++ b/README.md
@@ -75,20 +75,25 @@ HLS_MONITOR_INTERVAL=6000 # Interval in milliseconds for when a manifest should 
 ERROR_LIMIT=10 # number of errors to be saved in memory
 ```
 
-The `HLSMonitorService` can also be controlled through code:
+The `HLSMonitorService` can also be controlled through code by using the core `HLSMonitor` directly:
 
 ```typescript
-import { HLSMonitorService } from "@eyevinn/hls-monitor";
+import { HLSMonitor } from "@eyevinn/hls-monitor";
 
-// initialize a new instance of HLSMonitorService
-const hlsMonitorService = new HLSMonitorService();
+// Define a list of streams
+const streams = ["stream-to-monitor-01/manifest.m3u8", "stream-to-monitor-02/manifest.m3u8"];
 
-// create a new hls-monitor
-const streams = ["streams-to-monitor/manifest.m3u8"];
-hlsMonitorService.monitor.create(streams);
+// Define stale limit in miliseconds (Defaults at 6000)
+const staleLimit = 10000;
+
+// initialize a new instance of HLSMonitor
+const monitor = new HLSMonitor(streams, staleLimit);
+
+// Start the HLS-Monitor, it will begin polling and analyzing new manifests. 
+monitor.start();
 
 // Get latest errors
-const errors = hlsMonitorService.monitor.getErrors();
+const errors = monitor.getErrors();
 console.log(errors);
 ```
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ const monitor = new HLSMonitor(streams, staleLimit);
 // Start the HLS-Monitor, it will begin polling and analyzing new manifests. 
 monitor.start();
 
-// Get latest errors
+// ... after some time, check for the latest errors
 const errors = await monitor.getErrors();
 console.log(errors);
 ```

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ const monitor = new HLSMonitor(streams, staleLimit);
 monitor.start();
 
 // Get latest errors
-const errors = monitor.getErrors();
+const errors = await monitor.getErrors();
 console.log(errors);
 ```
 

--- a/src/HLSMonitorService.ts
+++ b/src/HLSMonitorService.ts
@@ -119,7 +119,7 @@ export class HLSMonitorService {
           message: "monitor not initialized",
         });
       }
-      reply.send({ streams: this.hlsMonitors.get(request.parms.monitorId).getStreamUrls() });
+      reply.send({ streams: this.hlsMonitors.get(request.params.monitorId).getStreamUrls() });
     });
 
     this.fastify.put("/monitor/:monitorId/streams", async (request, reply) => {


### PR DESCRIPTION
PR resolves #31 
And fixes a typo on path `monitor/:monitorId/streams`